### PR TITLE
Do a GET check of content if HEAD fails

### DIFF
--- a/harvester/image_harvest.py
+++ b/harvester/image_harvest.py
@@ -47,6 +47,18 @@ def link_is_to_image(url, auth=None):
     if not content_type:
         return False
     reg_type = content_type.split('/', 1)[0].lower()
+    #situation where a server returned 'text/html' to HEAD requests
+    # but returned 'image/jpeg' for GET.
+    # try a slower GET if not image type
+    if reg_type != 'image':
+        response = requests.get(url, allow_redirects=True,
+                                 auth=auth)
+        if response.status_code != 200:
+            return False
+        content_type = response.headers.get('content-type', None)
+        if not content_type:
+            return False
+        reg_type = content_type.split('/', 1)[0].lower()
     return reg_type == 'image'
 
 # Need to make each download a separate job.

--- a/harvester/solr_updater.py
+++ b/harvester/solr_updater.py
@@ -481,6 +481,7 @@ def get_sort_collection_data_string(collection):
     [sort_collection_name::collection_name::collection_url, <>,<>]
     '''
     sort_name = normalize_sort_field(collection['name'], 
+            default_missing='~collection unknown',
             missing_equivalents=[])
     sort_string = ':'.join((sort_name,
                             collection['name'],

--- a/test/test_image_harvest.py
+++ b/test/test_image_harvest.py
@@ -104,6 +104,13 @@ class ImageHarvestTestCase(TestCase):
                 content_type='text/plain; charset=utf-8',
                 connection='close',
                 )
+        httpretty.register_uri(httpretty.GET,
+                url,
+                body='',
+                content_length='0',
+                content_type='text/html; charset=utf-8',
+                connection='close',
+                )
         self.assertFalse(image_harvest.link_is_to_image(url))
         url = 'http://getthisimage/isanimage'
         httpretty.register_uri(httpretty.HEAD,
@@ -129,6 +136,21 @@ class ImageHarvestTestCase(TestCase):
                 connection='close',
                 )
         self.assertTrue(image_harvest.link_is_to_image(url))
+        httpretty.register_uri(httpretty.HEAD,
+                url,
+                body='',
+                content_length='0',
+                content_type='text/html; charset=utf-8',
+                connection='close',
+                )
+        httpretty.register_uri(httpretty.GET,
+                url,
+                body='',
+                content_length='0',
+                content_type='image/jpeg; charset=utf-8',
+                connection='close',
+                )
+        self.assertTrue(image_harvest.link_is_to_image(url))
 
     @patch('couchdb.Server')
     @patch('md5s3stash.md5s3stash', autospec=True,
@@ -146,6 +168,13 @@ class ImageHarvestTestCase(TestCase):
                 body='',
                 content_length='0',
                 content_type='text/plain; charset=utf-8',
+                connection='close',
+                )
+        httpretty.register_uri(httpretty.GET,
+                url,
+                body='',
+                content_length='0',
+                content_type='text/html; charset=utf-8',
                 connection='close',
                 )
         image_harvester = image_harvest.ImageHarvester(url_cache={},


### PR DESCRIPTION
Put in place for Chula Vista, their server return 'text/html' to HEAD requests but sends correct 'image/jpeg' to GET requests.