### PR TITLE
Make string only invocation of functions.

### DIFF
--- a/queue_image_harvest.bash
+++ b/queue_image_harvest.bash
@@ -32,7 +32,6 @@ NO ./bin/activate. You need to run
 . ./bin/activate
 pip install -r requirements.txt
 %%%
-    exit 13;
 fi
 # 48hr timeout = 172800 secs
 python scripts/queue_image_harvest.py --timeout=172800  ${@:1}

--- a/scripts/queue_deep_harvest.py
+++ b/scripts/queue_deep_harvest.py
@@ -5,7 +5,6 @@ import logbook
 from rq import Queue
 from redis import Redis
 from harvester.config import parse_env
-import s3stash.stash_collection
 
 JOB_TIMEOUT = 86400  # 24 hrs
 
@@ -26,7 +25,7 @@ def queue_deep_harvest(redis_host,
             password=redis_password,
             socket_connect_timeout=redis_timeout))
     job = rQ.enqueue_call(
-        func=s3stash.stash_collection.main,
+        func='s3stash.stash_collection.main',
         kwargs=dict(registry_id=collection_id),
         timeout=timeout)
     return job

--- a/scripts/queue_delete_solr_collection.py
+++ b/scripts/queue_delete_solr_collection.py
@@ -3,7 +3,6 @@
 import sys
 import logbook
 from harvester.config import config as config_harvest
-from harvester.solr_updater import delete_solr_collection
 from redis import Redis
 from rq import Queue
 
@@ -36,7 +35,7 @@ def queue_delete_from_solr(redis_host,
             password=redis_password,
             socket_connect_timeout=redis_timeout))
     job = rQ.enqueue_call(
-        func=delete_solr_collection,
+        func='harvester.solr_updater.delete_solr_collection',
         kwargs=dict(
             collection_key=collection_key),
             timeout=timeout)

--- a/scripts/queue_harvest.py
+++ b/scripts/queue_harvest.py
@@ -6,7 +6,6 @@ from redis import Redis
 from redis.exceptions import ConnectionError as RedisConnectionError
 from rq import Queue
 
-import harvester.run_ingest
 from harvester.config import config
 from harvester.config import RQ_Q_LIST
 
@@ -65,7 +64,7 @@ def main(user_email, url_api_collection,
     url_api_collection = [u.strip() for u in url_api_collection.split(';')]
     results = []
     for url in url_api_collection:
-        result = rQ.enqueue_call(func=harvester.run_ingest.main,
+        result = rQ.enqueue_call(func='harvester.run_ingest.main',
                                  args=(user_email, url),
                                  kwargs={'run_image_harvest':run_image_harvest,
                                          'rq_queue': rq_queue},

--- a/scripts/queue_image_harvest.py
+++ b/scripts/queue_image_harvest.py
@@ -5,12 +5,11 @@ Usage:
 """
 import sys
 import os
-import logbook
 from harvester.config import config as config_harvest
 from harvester.collection_registry_client import Collection
+import logbook
 from redis import Redis
 from rq import Queue
-import harvester.image_harvest
 
 EMAIL_RETURN_ADDRESS = os.environ.get('EMAIL_RETURN_ADDRESS',
                                       'example@example.com')
@@ -67,7 +66,7 @@ def queue_image_harvest(redis_host,
             password=redis_password,
             socket_connect_timeout=redis_timeout))
     job = rQ.enqueue_call(
-        func=harvester.image_harvest.main,
+        func='harvester.image_harvest.main',
         kwargs=dict(
             collection_key=collection_key,
             url_couchdb=url_couchdb,

--- a/scripts/queue_sync_couchdb_collection.py
+++ b/scripts/queue_sync_couchdb_collection.py
@@ -5,7 +5,6 @@ import logbook
 from rq import Queue
 from redis import Redis
 from harvester.config import parse_env
-import harvester.couchdb_sync_db_by_collection
 
 JOB_TIMEOUT = 28800  # 8 hrs
 URL_REMOTE_COUCHDB = 'https://harvest-stg.cdlib.org/couchdb'
@@ -28,7 +27,7 @@ def queue_couch_sync(redis_host,
             password=redis_password,
             socket_connect_timeout=redis_timeout))
     job = rQ.enqueue_call(
-        func=harvester.couchdb_sync_db_by_collection.main,
+        func='harvester.couchdb_sync_db_by_collection.main',
         kwargs=dict(
             url_remote_couchdb=url_remote_couchdb,
             url_api_collection=url_api_collection),

--- a/scripts/queue_sync_to_solr.py
+++ b/scripts/queue_sync_to_solr.py
@@ -3,7 +3,6 @@
 import sys
 import logbook
 from harvester.config import config as config_harvest
-from harvester.solr_updater import sync_couch_collection_to_solr
 from redis import Redis
 from rq import Queue
 
@@ -36,7 +35,7 @@ def queue_sync_to_solr(redis_host,
             password=redis_password,
             socket_connect_timeout=redis_timeout))
     job = rQ.enqueue_call(
-        func=sync_couch_collection_to_solr,
+        func='harvester.solr_updater.sync_couch_collection_to_solr',
         kwargs=dict(
             collection_key=collection_key),
             timeout=timeout)

--- a/setup_queuing_only.py
+++ b/setup_queuing_only.py
@@ -1,0 +1,41 @@
+# Setup for machines that only need to queue jobs.
+import os
+from setuptools import setup
+
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+# allow setup.py to be run from any path
+os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+
+setup(
+    name='UCLDC Harvester',
+    version='0.8.1',
+    py_modules=['harvester.config', ],
+    include_package_data=True,
+    license='BSD License - see LICENSE file',
+    description='Harvester installed for queuing jobs for the UCLDC project',
+    long_description=read('README.md'),
+    author='Mark Redar',
+    author_email='mark.redar@ucop.edu',
+    classifiers=[
+        'Environment :: Web Environment',
+        'Development Status :: 3 - Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Operating System :: Linux',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+    ],
+    install_requires=[
+        'requests==2.11.1',
+        'Logbook==0.6.0',
+        'redis==2.10.1',
+        'rq',
+        ],
+    test_suite='test',
+    tests_require=['mock>=1.0.1', 'httpretty==0.8.3', ],
+)


### PR DESCRIPTION
Not documented in RQ, but it handles strings for names of functions.
This allows decoupling.... Only a few dependencies for machines that
need to create jobs.