### PR TITLE
Fixes to tests for new PyOpenSSL & on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   # due to "secret" bitbucket with our modifications
   - "mkdir -p ${HOME}/.aws"
   - "cp awsconfig ~/.aws/config"
+  - "cp pynuxrc ~/.pynuxrc"
   - "pip install httpretty==0.8.3"
   - "pip install mock>=1.0.1"
   - "pip install git+https://github.com/mredar/ingestion.git"

--- a/harvester/fetcher/flickr_fetcher.py
+++ b/harvester/fetcher/flickr_fetcher.py
@@ -66,7 +66,7 @@ class Flickr_Fetcher(Fetcher):
         return tag_info
 
     def next(self):
-        if self.doc_current == self.docs_total:
+        if self.doc_current >= self.docs_total:
             if self.docs_fetched != self.docs_total:
                 raise ValueError(
                     "Number of documents fetched ({0}) doesn't match \

--- a/mypretty.py
+++ b/mypretty.py
@@ -1,0 +1,43 @@
+# from : https://github.com/gabrielfalcao/HTTPretty/issues/242
+from httpretty import HTTPretty as OriginalHTTPretty
+
+try:
+    from requests.packages.urllib3.contrib.pyopenssl import inject_into_urllib3, extract_from_urllib3
+    pyopenssl_override = True
+except:
+    pyopenssl_override = False
+
+
+class MyHTTPretty(OriginalHTTPretty):
+    """ pyopenssl monkey-patches the default ssl_wrap_socket() function in the 'requests' library,
+    but this can stop the HTTPretty socket monkey-patching from working for HTTPS requests.
+
+    Our version extends the base HTTPretty enable() and disable() implementations to undo
+    and redo the pyopenssl monkey-patching, respectively.
+    """
+
+    @classmethod
+    def enable(cls):
+        OriginalHTTPretty.enable()
+        if pyopenssl_override:
+            # Take out the pyopenssl version - use the default implementation
+            extract_from_urllib3()
+
+    @classmethod
+    def disable(cls):
+        OriginalHTTPretty.disable()
+        if pyopenssl_override:
+            # Put the pyopenssl version back in place
+            inject_into_urllib3()
+
+
+# Substitute in our version
+HTTPretty = MyHTTPretty
+
+import httpretty.core
+httpretty.core.httpretty = MyHTTPretty
+
+# May need to set other module-level attributes here, e.g. enable, reset etc,
+# depending on your needs
+import httpretty
+httpretty.httpretty = MyHTTPretty

--- a/pynuxrc
+++ b/pynuxrc
@@ -1,0 +1,7 @@
+[nuxeo_account]
+user = user
+password = pswd
+
+[rest_api]
+base = https://nuxeo.cdlib.org/Nuxeo/site/api/v1
+X-NXDocumentProperties = dublincore,ucldc_schema,picture,file,video

--- a/test/test_cmisatomfeed_fetcher.py
+++ b/test/test_cmisatomfeed_fetcher.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
-import httpretty
+from mypretty import httpretty
+# import httpretty
 import harvester.fetcher as fetcher
 from test.utils import LogOverrideMixin
 from test.utils import DIR_FIXTURES

--- a/test/test_collection_registry_client.py
+++ b/test/test_collection_registry_client.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 import json
 import StringIO
-import httpretty
+from mypretty import httpretty
+# import httpretty
 from mock import patch
 from harvester.collection_registry_client import Registry, Collection
 from test.utils import DIR_FIXTURES

--- a/test/test_couchdb_runner.py
+++ b/test/test_couchdb_runner.py
@@ -1,7 +1,8 @@
 import os
 from unittest import TestCase
 import re
-import httpretty
+from mypretty import httpretty
+# import httpretty
 from mock import patch
 from test.utils import DIR_FIXTURES
 from harvester.config import config

--- a/test/test_enrich_existing_couch_doc.py
+++ b/test/test_enrich_existing_couch_doc.py
@@ -2,7 +2,8 @@ import os
 from unittest import TestCase
 import json
 import re
-import httpretty
+from mypretty import httpretty
+# import httpretty
 from mock import patch
 from test.utils import DIR_FIXTURES
 from harvester.config import config

--- a/test/test_flickr_fetcher.py
+++ b/test/test_flickr_fetcher.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 import harvester.fetcher as fetcher
 from test.utils import DIR_FIXTURES
 from test.utils import LogOverrideMixin
-import httpretty
+from mypretty import httpretty
+# import httpretty
 
 
 class FlickrFetcherTestCase(LogOverrideMixin, TestCase):

--- a/test/test_harvestcontroller.py
+++ b/test/test_harvestcontroller.py
@@ -4,7 +4,8 @@ from unittest import skip
 import shutil
 import re
 import json
-import httpretty
+from mypretty import httpretty
+# import httpretty
 from mock import patch
 from test.utils import ConfigFileOverrideMixin, LogOverrideMixin
 from test.utils import DIR_FIXTURES, TEST_COUCH_DASHBOARD, TEST_COUCH_DB

--- a/test/test_image_harvest.py
+++ b/test/test_image_harvest.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 from collections import namedtuple
 from mock import patch
 from mock import MagicMock
-import httpretty
+from mypretty import httpretty
+# import httpretty
 from harvester import image_harvest
 
 #TODO: make this importable from md5s3stash
@@ -92,7 +93,7 @@ class ImageHarvestTestCase(TestCase):
         db.save.assert_called_with({'_id': 'TESTID',
             'object': 'md5 test value',
             'object_dimensions': 'dimensions-x:y'})
-    
+
     @httpretty.activate
     def test_link_is_to_image(self):
         '''Test the link_is_to_image function'''
@@ -158,7 +159,7 @@ class ImageHarvestTestCase(TestCase):
                 's3 url object', 'mime_type', 'dimensions'))
     @httpretty.activate
     def test_check_content_type(self, mock_stash, mock_couch):
-        '''Test that the check for content type correctly aborts if the 
+        '''Test that the check for content type correctly aborts if the
         type is not a image
         '''
         url = 'http://getthisimage/notanimage'
@@ -199,10 +200,10 @@ class ImageHarvestTestCase(TestCase):
         schema. The LAPL photo feed has URLs like this:
 
         http:/jpg1.lapl.org/pics47/00043006.jpg
-        
-        The code was choking complaining about a "MissingSchema" 
+
+        The code was choking complaining about a "MissingSchema"
         exception.
         '''
         pass
 
-        
+

--- a/test/test_marc_fetcher.py
+++ b/test/test_marc_fetcher.py
@@ -4,7 +4,8 @@ import shutil
 from harvester.collection_registry_client import Collection
 from test.utils import ConfigFileOverrideMixin, LogOverrideMixin
 from test.utils import DIR_FIXTURES
-import httpretty
+from mypretty import httpretty
+# import httpretty
 import harvester.fetcher as fetcher
 
 

--- a/test/test_nuxeo_fetcher.py
+++ b/test/test_nuxeo_fetcher.py
@@ -6,7 +6,8 @@ import json
 import re
 import shutil
 from mock import patch
-import httpretty
+from mypretty import httpretty
+# import httpretty
 import pynux.utils
 from harvester.collection_registry_client import Collection
 from test.utils import DIR_FIXTURES
@@ -267,7 +268,7 @@ class NuxeoFetcherTestCase(LogOverrideMixin, TestCase):
     @patch('boto.connect_s3', autospec=True)
     @patch('harvester.fetcher.nuxeo_fetcher.DeepHarvestNuxeo', autospec=True)
     def test_get_isShownBy_video(self, mock_deepharvest, mock_boto):
-        ''' test getting correct isShownBy value for Nuxeo video object 
+        ''' test getting correct isShownBy value for Nuxeo video object
         '''
         deepharvest_mocker(mock_deepharvest)
 

--- a/test/test_oac_fetcher.py
+++ b/test/test_oac_fetcher.py
@@ -4,7 +4,8 @@ import json
 from unittest import TestCase
 import shutil
 from xml.etree import ElementTree as ET
-import httpretty
+from mypretty import httpretty
+# import httpretty
 import harvester.fetcher as fetcher
 from harvester.collection_registry_client import Collection
 from test.utils import ConfigFileOverrideMixin, LogOverrideMixin

--- a/test/test_oai_fetcher.py
+++ b/test/test_oai_fetcher.py
@@ -5,7 +5,8 @@ from test.utils import ConfigFileOverrideMixin, LogOverrideMixin
 from test.utils import DIR_FIXTURES
 from harvester.collection_registry_client import Collection
 import harvester.fetcher as fetcher
-import httpretty
+from mypretty import httpretty
+# import httpretty
 
 
 class HarvestOAIControllerTestCase(ConfigFileOverrideMixin,

--- a/test/test_run_ingest.py
+++ b/test/test_run_ingest.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 import shutil
 import re
 import pickle
-import httpretty
+from mypretty import httpretty
+# import httpretty
 import logbook
 from mock import patch
 from mock import MagicMock
@@ -349,7 +350,7 @@ class RunIngestTestCase(LogOverrideMixin, TestCase):
         mail_handler = MagicMock()
         url_api_collection = 'https://registry.cdlib.org/api/v1/collection/' \
             '178/'
-        httpretty.enable()
+        httpretty.httpretty.enable()
         httpretty.register_uri(
             httpretty.GET,
             url_api_collection,
@@ -398,7 +399,7 @@ class RunIngestTestCase(LogOverrideMixin, TestCase):
         mail_handler = MagicMock()
         url_api_collection = 'https://registry.cdlib.org/api/v1/' \
             'collection/178/'
-        httpretty.enable()
+        httpretty.httpretty.enable()
         httpretty.register_uri(
             httpretty.GET,
             url_api_collection,

--- a/test/test_solr_fetcher.py
+++ b/test/test_solr_fetcher.py
@@ -6,7 +6,8 @@ from harvester.collection_registry_client import Collection
 import solr
 import pysolr
 import harvester.fetcher as fetcher
-import httpretty
+from mypretty import httpretty
+# import httpretty
 
 
 class SolrFetcherTestCase(LogOverrideMixin, TestCase):

--- a/test/test_ucsf_xml_fetcher.py
+++ b/test/test_ucsf_xml_fetcher.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from unittest import TestCase
-import httpretty
+from mypretty import httpretty
+# import httpretty
 import harvester.fetcher as fetcher
 from test.utils import DIR_FIXTURES
 from test.utils import LogOverrideMixin


### PR DESCRIPTION
Fixed testing locally and on travis.

A new PyOpenSSL mucked with httpretty and the newer pynux really needs .pynuxrc