### PR TITLE
New requests based solr fetcher for more flexible usage

### DIFF
--- a/harvester/fetcher/__init__.py
+++ b/harvester/fetcher/__init__.py
@@ -5,6 +5,7 @@ from .solr_fetcher import SolrFetcher
 from .solr_fetcher import PySolrFetcher
 from .solr_fetcher import PySolrQueryFetcher
 from .solr_fetcher import PySolrUCBFetcher
+from .solr_fetcher import RequestsSolrFetcher
 from .marc_fetcher import MARCFetcher
 from .marc_fetcher import AlephMARCXMLFetcher
 from .nuxeo_fetcher import NuxeoFetcher
@@ -27,5 +28,5 @@ __all__ = (Fetcher, NoRecordsFetchedException, HARVEST_TYPES, OAIFetcher,
            NuxeoFetcher, UCLDCNuxeoFetcher, OAC_XML_Fetcher, OAC_JSON_Fetcher,
            UCSF_XML_Fetcher, CMISAtomFeedFetcher, HarvestController,
            PySolrQueryFetcher, PySolrUCBFetcher, Flickr_Fetcher,
-           YouTube_Fetcher,
+           YouTube_Fetcher, RequestsSolrFetcher,
            EMAIL_RETURN_ADDRESS, get_log_file_path, main)

--- a/harvester/fetcher/__init__.py
+++ b/harvester/fetcher/__init__.py
@@ -4,7 +4,6 @@ from .oai_fetcher import OAIFetcher
 from .solr_fetcher import SolrFetcher
 from .solr_fetcher import PySolrFetcher
 from .solr_fetcher import PySolrQueryFetcher
-from .solr_fetcher import PySolrUCBFetcher
 from .solr_fetcher import RequestsSolrFetcher
 from .marc_fetcher import MARCFetcher
 from .marc_fetcher import AlephMARCXMLFetcher
@@ -27,6 +26,6 @@ __all__ = (Fetcher, NoRecordsFetchedException, HARVEST_TYPES, OAIFetcher,
            SolrFetcher, PySolrFetcher, MARCFetcher, AlephMARCXMLFetcher,
            NuxeoFetcher, UCLDCNuxeoFetcher, OAC_XML_Fetcher, OAC_JSON_Fetcher,
            UCSF_XML_Fetcher, CMISAtomFeedFetcher, HarvestController,
-           PySolrQueryFetcher, PySolrUCBFetcher, Flickr_Fetcher,
+           PySolrQueryFetcher, Flickr_Fetcher,
            YouTube_Fetcher, RequestsSolrFetcher,
            EMAIL_RETURN_ADDRESS, get_log_file_path, main)

--- a/harvester/fetcher/controller.py
+++ b/harvester/fetcher/controller.py
@@ -27,24 +27,24 @@ from .cmis_atom_feed_fetcher import CMISAtomFeedFetcher
 from .flickr_fetcher import Flickr_Fetcher
 from .youtube_fetcher import YouTube_Fetcher
 
-
 EMAIL_RETURN_ADDRESS = os.environ.get('EMAIL_RETURN_ADDRESS',
                                       'example@example.com')
-HARVEST_TYPES = {'OAI': OAIFetcher,
-                 'OAJ': OAC_JSON_Fetcher,
-                 'OAC': OAC_XML_Fetcher,
-                 'SLR': SolrFetcher,
-                 'MRC': MARCFetcher,
-                 'NUX': UCLDCNuxeoFetcher,
-                 'ALX': AlephMARCXMLFetcher,
-                 'SFX': PySolrQueryFetcher,
-                 'UCB': RequestsSolrFetcher,  # Now points to more generic
-                                              # class, accepts parameters
-                                              # from extra data field
-                 'PRE': CMISAtomFeedFetcher,  # 'Preservica CMIS Atom Feed'),
-                 'FLK': Flickr_Fetcher, # All public photos fetcher
-                 'YTB': YouTube_Fetcher, # by playlist id, use "uploads" list
-                 }
+HARVEST_TYPES = {
+    'OAI': OAIFetcher,
+    'OAJ': OAC_JSON_Fetcher,
+    'OAC': OAC_XML_Fetcher,
+    'SLR': SolrFetcher,
+    'MRC': MARCFetcher,
+    'NUX': UCLDCNuxeoFetcher,
+    'ALX': AlephMARCXMLFetcher,
+    'SFX': PySolrQueryFetcher,
+    'UCB': RequestsSolrFetcher,  # Now points to more generic
+    # class, accepts parameters
+    # from extra data field
+    'PRE': CMISAtomFeedFetcher,  # 'Preservica CMIS Atom Feed'),
+    'FLK': Flickr_Fetcher,  # All public photos fetcher
+    'YTB': YouTube_Fetcher,  # by playlist id, use "uploads" list
+}
 
 
 class HarvestController(object):
@@ -53,14 +53,22 @@ class HarvestController(object):
     disk.
     TODO: produce profile file
     '''
-    campus_valid = ['UCB', 'UCD', 'UCI', 'UCLA', 'UCM', 'UCR', 'UCSB', 'UCSC',
-                    'UCSD', 'UCSF', 'UCDL']
-    dc_elements = ['title', 'creator', 'subject', 'description', 'publisher',
-                   'contributor', 'date', 'type', 'format', 'identifier',
-                   'source', 'language', 'relation', 'coverage', 'rights']
+    campus_valid = [
+        'UCB', 'UCD', 'UCI', 'UCLA', 'UCM', 'UCR', 'UCSB', 'UCSC', 'UCSD',
+        'UCSF', 'UCDL'
+    ]
+    dc_elements = [
+        'title', 'creator', 'subject', 'description', 'publisher',
+        'contributor', 'date', 'type', 'format', 'identifier', 'source',
+        'language', 'relation', 'coverage', 'rights'
+    ]
 
-    def __init__(self, user_email, collection, profile_path=None,
-                 config_file=None, **kwargs):
+    def __init__(self,
+                 user_email,
+                 collection,
+                 profile_path=None,
+                 config_file=None,
+                 **kwargs):
         self.user_email = user_email  # single or list
         self.collection = collection
         self.profile_path = profile_path
@@ -101,17 +109,17 @@ class HarvestController(object):
         if not type(objset) == list:
             objset = [objset]
         with open(filename, 'w') as foo:
-            foo.write(json.dumps(objset,
-                      default=HarvestController.dt_json_handler))
+            foo.write(
+                json.dumps(
+                    objset, default=HarvestController.dt_json_handler))
 
     def create_ingest_doc(self):
         '''Create the DPLA style ingest doc in couch for this harvest session.
         Update with the current information. Status is running'''
         self.couch = dplaingestion.couch.Couch(
-                config_file=self.config_file,
-                dpla_db_name=self.couch_db_name,
-                dashboard_db_name=self.couch_dashboard_name
-                )
+            config_file=self.config_file,
+            dpla_db_name=self.couch_db_name,
+            dashboard_db_name=self.couch_dashboard_name)
         uri_base = "http://localhost:" + self._config['akara_port']
         self.ingest_doc_id = self.couch._create_ingestion_document(
             self.collection.provider, uri_base, self.profile_path,
@@ -134,7 +142,10 @@ class HarvestController(object):
             raise e
         return self.ingest_doc_id
 
-    def update_ingest_doc(self, status, error_msg=None, items=None,
+    def update_ingest_doc(self,
+                          status,
+                          error_msg=None,
+                          items=None,
                           num_coll=None):
         '''Update the ingest doc with status'''
         if not items:
@@ -164,7 +175,8 @@ class HarvestController(object):
         url_tuple = urlparse.urlparse(self.collection.url)
         base_url = ''.join((url_tuple.scheme, '://', url_tuple.netloc))
         self.collection['@id'] = self.collection.url
-        self.collection['id'] = self.collection.url.strip('/').rsplit('/', 1)[1]
+        self.collection['id'] = self.collection.url.strip('/').rsplit('/',
+                                                                      1)[1]
         self.collection['ingestType'] = 'collection'
         self.collection['title'] = self.collection.name
         if 'collection' in obj:
@@ -187,10 +199,10 @@ class HarvestController(object):
 
     def harvest(self):
         '''Harvest the collection'''
-        self.logger.info(' '.join(('Starting harvest for:',
-                                   str(self.user_email), self.collection.url,
-                                   str(self.collection['campus']),
-                                   str(self.collection['repository']))))
+        self.logger.info(' '.join(('Starting harvest for:', str(
+            self.user_email), self.collection.url,
+            str(self.collection['campus']),
+            str(self.collection['repository']))))
         self.num_records = 0
         next_log_n = interval = 100
         for objset in self.fetcher:
@@ -205,9 +217,10 @@ class HarvestController(object):
             self.save_objset(objset)
             if self.num_records >= next_log_n:
                 self.logger.info(' '.join((str(self.num_records),
-                                 'records harvested')))
-                if self.num_records < 10000 and self.num_records >= 10*interval:
-                    interval = 10*interval
+                                           'records harvested')))
+                if self.num_records < 10000 and \
+                        self.num_records >= 10 * interval:
+                    interval = 10 * interval
                 next_log_n += interval
 
         if self.num_records == 0:
@@ -222,21 +235,23 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Harvest a collection')
     parser.add_argument('user_email', type=str, nargs='?', help='user email')
     parser.add_argument(
-            'url_api_collection', type=str, nargs='?',
-            help='URL for the collection Django tastypie api resource')
+        'url_api_collection',
+        type=str,
+        nargs='?',
+        help='URL for the collection Django tastypie api resource')
     return parser.parse_args()
 
 
 def get_log_file_path(collection_slug):
-    '''Get the log file name for the given collection, start time and environment
+    '''Get the log file name for the given collection, start time and
+    environment
     '''
     log_file_dir = os.environ.get('DIR_HARVESTER_LOG',
-                                  os.path.join(os.environ.get('HOME', '.'),
-                                               'log')
-                                  )
-    log_file_name = '-'.join(('harvester', collection_slug,
-                             datetime.datetime.now().strftime('%Y%m%d-%H%M%S'),
-                             '.log'))
+                                  os.path.join(
+                                      os.environ.get('HOME', '.'), 'log'))
+    log_file_name = '-'.join(
+        ('harvester', collection_slug,
+         datetime.datetime.now().strftime('%Y%m%d-%H%M%S'), '.log'))
     return os.path.join(log_file_dir, log_file_name)
 
 
@@ -248,9 +263,14 @@ def create_mimetext_msg(mail_from, mail_to, subject, message):
     return msg
 
 
-def main(user_email, url_api_collection, log_handler=None, mail_handler=None,
-         dir_profile='profiles', profile_path=None,
-         config_file=None, **kwargs):
+def main(user_email,
+         url_api_collection,
+         log_handler=None,
+         mail_handler=None,
+         dir_profile='profiles',
+         profile_path=None,
+         config_file=None,
+         **kwargs):
     '''Executes a harvest with given parameters.
     Returns the ingest_doc_id, directory harvest saved to and number of
     records.
@@ -260,10 +280,8 @@ def main(user_email, url_api_collection, log_handler=None, mail_handler=None,
     num_recs = -1
     my_mail_handler = None
     if not mail_handler:
-        my_mail_handler = logbook.MailHandler(EMAIL_RETURN_ADDRESS,
-                                              user_email,
-                                              level='ERROR',
-                                              bubble=True)
+        my_mail_handler = logbook.MailHandler(
+            EMAIL_RETURN_ADDRESS, user_email, level='ERROR', bubble=True)
         my_mail_handler.push_application()
         mail_handler = my_mail_handler
     try:
@@ -273,13 +291,12 @@ def main(user_email, url_api_collection, log_handler=None, mail_handler=None,
                                                            str(e))
         logbook.error(msg)
         raise e
-    if not(collection['harvest_type'] in HARVEST_TYPES):
+    if not (collection['harvest_type'] in HARVEST_TYPES):
         msg = 'Collection {} wrong type {} for harvesting. Harvest type {} \
                 is not in {}'.format(url_api_collection,
                                      collection['harvest_type'],
                                      collection['harvest_type'],
-                                     HARVEST_TYPES.keys()
-                                     )
+                                     HARVEST_TYPES.keys())
         logbook.error(msg)
         raise ValueError(msg)
     mail_handler.subject = "Error during harvest of " + collection.url
@@ -291,10 +308,8 @@ def main(user_email, url_api_collection, log_handler=None, mail_handler=None,
     msg = 'Init harvester next. Collection:{}'.format(collection.url)
     logger.info(msg)
     # email directly
-    mimetext = create_mimetext_msg(EMAIL_RETURN_ADDRESS, user_email,
-                                   ' '.join(('Starting harvest for ',
-                                            collection.slug)),
-                                   msg)
+    mimetext = create_mimetext_msg(EMAIL_RETURN_ADDRESS, user_email, ' '.join(
+        ('Starting harvest for ', collection.slug)), msg)
     try:  # TODO: request more emails from AWS
         mail_handler.deliver(mimetext, 'mredar@gmail.com')
     except:
@@ -302,19 +317,22 @@ def main(user_email, url_api_collection, log_handler=None, mail_handler=None,
     logger.info('Create DPLA profile document')
     if not profile_path:
         profile_path = os.path.abspath(
-            os.path.join(dir_profile, collection.id+'.pjs'))
+            os.path.join(dir_profile, collection.id + '.pjs'))
     with codecs.open(profile_path, 'w', 'utf8') as pfoo:
         pfoo.write(collection.dpla_profile)
-    logger.info('DPLA profile document : '+profile_path)
+    logger.info('DPLA profile document : ' + profile_path)
     harvester = None
     try:
-        harvester = HarvestController(user_email, collection,
-                                      profile_path=profile_path,
-                                      config_file=config_file, **kwargs)
+        harvester = HarvestController(
+            user_email,
+            collection,
+            profile_path=profile_path,
+            config_file=config_file,
+            **kwargs)
     except Exception, e:
         import traceback
         msg = 'Exception in harvester init: type: {} TRACE:\n{}'.format(
-              type(e), traceback.format_exc())
+            type(e), traceback.format_exc())
         logger.error(msg)
         raise e
     logger.info('Create ingest doc in couch')
@@ -323,18 +341,15 @@ def main(user_email, url_api_collection, log_handler=None, mail_handler=None,
     logger.info('Start harvesting next')
     try:
         num_recs = harvester.harvest()
-        msg = ''.join(('Finished harvest of ', collection.slug,
-                       '. ', str(num_recs), ' records harvested.'))
+        msg = ''.join(('Finished harvest of ', collection.slug, '. ',
+                       str(num_recs), ' records harvested.'))
         harvester.update_ingest_doc('complete', items=num_recs, num_coll=1)
         logger.info(msg)
         # email directly
-        mimetext = create_mimetext_msg(EMAIL_RETURN_ADDRESS, user_email,
-                                       ' '.join((
-                                           'Finished harvest of raw records '
-                                           'for ',
-                                           collection.slug,
-                                           ' enriching next')),
-                                       msg)
+        mimetext = create_mimetext_msg(
+            EMAIL_RETURN_ADDRESS, user_email, ' '.join(
+                ('Finished harvest of raw records '
+                 'for ', collection.slug, ' enriching next')), msg)
         try:
             mail_handler.deliver(mimetext, 'mredar@gmail.com')
         except:
@@ -342,16 +357,17 @@ def main(user_email, url_api_collection, log_handler=None, mail_handler=None,
     except Exception, e:
         import traceback
         error_msg = ''.join(("Error while harvesting: type-> ", str(type(e)),
-                             " TRACE:\n"+str(traceback.format_exc())))
+                             " TRACE:\n" + str(traceback.format_exc())))
         logger.error(error_msg)
-        harvester.update_ingest_doc('error', error_msg=error_msg,
-                                    items=num_recs)
+        harvester.update_ingest_doc(
+            'error', error_msg=error_msg, items=num_recs)
         raise e
     if my_log_handler:
         my_log_handler.pop_application()
     if my_mail_handler:
         my_mail_handler.pop_application()
     return ingest_doc_id, num_recs, harvester.dir_save, harvester
+
 
 __all__ = (Fetcher, NoRecordsFetchedException, HARVEST_TYPES)
 

--- a/harvester/fetcher/controller.py
+++ b/harvester/fetcher/controller.py
@@ -17,7 +17,7 @@ from .fetcher import NoRecordsFetchedException
 from .oai_fetcher import OAIFetcher
 from .solr_fetcher import SolrFetcher
 from .solr_fetcher import PySolrQueryFetcher
-from .solr_fetcher import PySolrUCBFetcher
+from .solr_fetcher import RequestsSolrFetcher
 from .marc_fetcher import MARCFetcher
 from .marc_fetcher import AlephMARCXMLFetcher
 from .nuxeo_fetcher import UCLDCNuxeoFetcher
@@ -38,7 +38,9 @@ HARVEST_TYPES = {'OAI': OAIFetcher,
                  'NUX': UCLDCNuxeoFetcher,
                  'ALX': AlephMARCXMLFetcher,
                  'SFX': PySolrQueryFetcher,
-                 'UCB': PySolrUCBFetcher,
+                 'UCB': RequestsSolrFetcher,  # Now points to more generic
+                                              # class, accepts parameters
+                                              # from extra data field
                  'PRE': CMISAtomFeedFetcher,  # 'Preservica CMIS Atom Feed'),
                  'FLK': Flickr_Fetcher, # All public photos fetcher
                  'YTB': YouTube_Fetcher, # by playlist id, use "uploads" list

--- a/harvester/fetcher/solr_fetcher.py
+++ b/harvester/fetcher/solr_fetcher.py
@@ -110,9 +110,10 @@ class RequestsSolrFetcher(Fetcher):
 
     def __init__(self, url_harvest, extra_data):
         super(RequestsSolrFetcher, self).__init__(url_harvest, extra_data)
+        if '/select' not in self.url and '/query' not in self.url:
+            self.url = ''.join((self.url, '/select'))
         self._query_iter_template = \
             '?rows={rows}&cursorMark={cursorMark}'
-        self.solr_path = '/select'
         self._query_params = urlparse.parse_qs(extra_data)
         if not self._query_params:  # Old style, just "q" bit of query
             self._query_params = {'q': [extra_data]}
@@ -140,7 +141,6 @@ class RequestsSolrFetcher(Fetcher):
         # build current URL
         url_request = ''.join((
             self.url,
-            self.solr_path,
             self._query_iter_template.format(
                 rows=self._page_size,
                 cursorMark=self._cursorMark),

--- a/harvester/fetcher/solr_fetcher.py
+++ b/harvester/fetcher/solr_fetcher.py
@@ -110,8 +110,8 @@ class RequestsSolrFetcher(Fetcher):
 
     def __init__(self, url_harvest, extra_data):
         super(RequestsSolrFetcher, self).__init__(url_harvest, extra_data)
-        if '/select' not in self.url and '/query' not in self.url:
-            self.url = ''.join((self.url, '/select'))
+        # will need to change URLs for existing to add /select in general
+        # the bampfa has NO /select or /query
         self._query_iter_template = \
             '?rows={rows}&cursorMark={cursorMark}'
         self._query_params = urlparse.parse_qs(extra_data)

--- a/harvester/fetcher/solr_fetcher.py
+++ b/harvester/fetcher/solr_fetcher.py
@@ -121,8 +121,8 @@ class RequestsSolrFetcher(Fetcher):
         self._cursorMark = None
         self._nextCursorMark = '*'
         self._query_params.update({
-            'wt': 'json',
-            'sort': 'id asc',
+            'wt': ['json'],
+            'sort': ['id asc'],
         })
         self._headers = {}
         for name, value in self._query_params.items():

--- a/harvester/fetcher/solr_fetcher.py
+++ b/harvester/fetcher/solr_fetcher.py
@@ -88,15 +88,6 @@ class PySolrQueryFetcher(PySolrFetcher):
             url_harvest, query, handler_path='query', **query_params)
 
 
-class PySolrUCBFetcher(PySolrFetcher):
-    '''Add the qt=document parameter for UCB blacklight'''
-
-    def __init__(self, url_harvest, query, **query_params):
-        query_params.update({'qt': 'document'})
-        super(PySolrUCBFetcher, self).__init__(url_harvest, query,
-                                               **query_params)
-
-
 class RequestsSolrFetcher(Fetcher):
     '''A fetcher for solr that uses just the requests library
     The URL is the URL up to the "select" bit (may change in future)

--- a/test/test_solr_fetcher.py
+++ b/test/test_solr_fetcher.py
@@ -195,7 +195,7 @@ class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
         '''Test the RequestSolrFetcher iteration over a mock set of data'''
         httpretty.register_uri(
             httpretty.GET,
-            'http://example.edu/solr/select',
+            'http://example.edu/solr',
             responses=[
                 httpretty.Response(body=open(
                     DIR_FIXTURES + '/ucb-cursor-results-0.json').read()),
@@ -237,12 +237,12 @@ class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
             'q=extra:data&header=app-name:Value-with:in-it'
             '&header=app_key:111222333')
         self.assertEqual(
-            'http://example.edu/solr/select?rows=1000&cursorMark=None'
+            'http://example.edu/solr?rows=1000&cursorMark=None'
             '&q=extra:data&wt=json&sort=id asc',
             h.url_request)
         h._cursorMark = 'XXXX'
         self.assertEqual(
-            'http://example.edu/solr/select?rows=1000&cursorMark=XXXX'
+            'http://example.edu/solr?rows=1000&cursorMark=XXXX'
             '&q=extra:data&wt=json&sort=id asc',
             h.url_request)
 

--- a/test/test_solr_fetcher.py
+++ b/test/test_solr_fetcher.py
@@ -7,6 +7,7 @@ import solr
 import pysolr
 import harvester.fetcher as fetcher
 from mypretty import httpretty
+
 # import httpretty
 
 
@@ -20,13 +21,11 @@ class SolrFetcherTestCase(LogOverrideMixin, TestCase):
         httpretty.register_uri(
             httpretty.POST,
             'http://example.edu/solr/select',
-            body=open(
-                DIR_FIXTURES +
-                '/ucsd-new-feed-missions-bb3038949s-0.xml').read()
-            )
+            body=open(DIR_FIXTURES +
+                      '/ucsd-new-feed-missions-bb3038949s-0.xml').read())
         self.assertRaises(TypeError, fetcher.SolrFetcher)
-        h = fetcher.SolrFetcher('http://example.edu/solr', 'extra_data',
-                                rows=3)
+        h = fetcher.SolrFetcher(
+            'http://example.edu/solr', 'extra_data', rows=3)
         self.assertTrue(hasattr(h, 'solr'))
         self.assertTrue(isinstance(h.solr, solr.Solr))
         self.assertEqual(h.solr.url, 'http://example.edu/solr')
@@ -47,24 +46,23 @@ class SolrFetcherTestCase(LogOverrideMixin, TestCase):
             'http://example.edu/solr/select',
             responses=[
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-0.xml').read()),
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-0.xml')
+                    .read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-1.xml').read()),
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-1.xml')
+                    .read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-2.xml').read()),
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-2.xml')
+                    .read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-3.xml').read()),
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-3.xml')
+                    .read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-4.xml').read())
-            ]
-            )
-        h = fetcher.SolrFetcher('http://example.edu/solr', 'extra_data',
-                                rows=3)
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-4.xml')
+                    .read())
+            ])
+        h = fetcher.SolrFetcher(
+            'http://example.edu/solr', 'extra_data', rows=3)
         self.assertEqual(len(h.resp.results), 3)
         n = 0
         for r in h:
@@ -81,15 +79,14 @@ class PySolrQueryFetcherTestCase(LogOverrideMixin, TestCase):
         '''Test that the class exists and gives good error messages
         if initial data not correct'''
         httpretty.register_uri(
-                httpretty.GET,
-                'http://example.edu/solr/query',
-                body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-0.json').read()
-                )
+            httpretty.GET,
+            'http://example.edu/solr/query',
+            body=open(DIR_FIXTURES +
+                      '/ucsd-new-feed-missions-bb3038949s-0.json').read())
         self.assertRaises(TypeError, fetcher.PySolrQueryFetcher)
-        h = fetcher.PySolrQueryFetcher('http://example.edu/solr',
-                                       'extra_data',)
+        h = fetcher.PySolrQueryFetcher(
+            'http://example.edu/solr',
+            'extra_data', )
         self.assertTrue(hasattr(h, 'solr'))
         self.assertTrue(isinstance(h.solr, pysolr.Solr))
         self.assertEqual(h.solr.url, 'http://example.edu/solr')
@@ -107,25 +104,24 @@ class PySolrQueryFetcherTestCase(LogOverrideMixin, TestCase):
             'http://example.edu/solr/query',
             responses=[
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-0.json').read()),
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-0.json')
+                    .read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-1.json').read()),
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-1.json')
+                    .read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-2.json').read()),
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-2.json')
+                    .read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucsd-new-feed-missions-bb3038949s-3.json').read()),
-            ]
-        )
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-3.json')
+                    .read()),
+            ])
         self.assertRaises(TypeError, fetcher.PySolrFetcher)
         h = fetcher.PySolrQueryFetcher('http://example.edu/solr', 'extra_data',
                                        **{'rows': 3})
         self.assertEqual(
-                h._query_path,
-                'query?q=extra_data&sort=id+asc&cursorMark=%2A&wt=json&rows=3')
+            h._query_path,
+            'query?q=extra_data&sort=id+asc&cursorMark=%2A&wt=json&rows=3')
         n = 0
         for r in h:
             n += 1
@@ -135,20 +131,17 @@ class PySolrQueryFetcherTestCase(LogOverrideMixin, TestCase):
 
 class PySolrUCBFetcherTestCase(LogOverrideMixin, TestCase):
     '''Test the UCB fetcher'''
+
     @httpretty.activate
     def testClassInit(self):
         '''Test that the class exists and gives good error messages
         if initial data not correct'''
         httpretty.register_uri(
-                httpretty.GET,
-                'http://example.edu/solr/select',
-                body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-0.json').read()
-                )
+            httpretty.GET,
+            'http://example.edu/solr/select',
+            body=open(DIR_FIXTURES + '/ucb-cursor-results-0.json').read())
         self.assertRaises(TypeError, fetcher.PySolrUCBFetcher)
-        h = fetcher.PySolrUCBFetcher('http://example.edu/solr',
-                                     'extra_data',
+        h = fetcher.PySolrUCBFetcher('http://example.edu/solr', 'extra_data',
                                      **{'rows': 1})
         self.assertTrue(hasattr(h, 'solr'))
         self.assertTrue(isinstance(h.solr, pysolr.Solr))
@@ -166,25 +159,19 @@ class PySolrUCBFetcherTestCase(LogOverrideMixin, TestCase):
             'http://example.edu/solr/select',
             responses=[
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-0.json').read()),
+                    DIR_FIXTURES + '/ucb-cursor-results-0.json').read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-1.json').read()),
+                    DIR_FIXTURES + '/ucb-cursor-results-1.json').read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-2.json').read()),
+                    DIR_FIXTURES + '/ucb-cursor-results-2.json').read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-3.json').read()),
-            ]
-        )
+                    DIR_FIXTURES + '/ucb-cursor-results-3.json').read()),
+            ])
         h = fetcher.PySolrUCBFetcher('http://example.edu/solr', 'extra_data',
                                      **{'rows': 1})
-        self.assertEqual(
-                h._query_path,
-                'select?q=extra_data&sort=id+asc&cursorMark=%2A'
-                '&qt=document&wt=json&rows=1')
+        self.assertEqual(h._query_path,
+                         'select?q=extra_data&sort=id+asc&cursorMark=%2A'
+                         '&qt=document&wt=json&rows=1')
         cursor = h._nextCursorMark
         docs = []
         docs.append(h.next())  # gets the one from init, no get_next_results
@@ -195,13 +182,14 @@ class PySolrUCBFetcherTestCase(LogOverrideMixin, TestCase):
         docs.append(h.next())  # get_next_results
         self.assertNotEqual(cursor, h._nextCursorMark)
         cursor = h._nextCursorMark
-        docs.append(h.next())   # get_next_results
+        docs.append(h.next())  # get_next_results
         self.assertNotEqual(cursor, h._nextCursorMark)
         self.assertEqual(len(docs), 4)
 
 
 class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
     '''Test the Request Solr fetcher which uses cursorMark'''
+
     @httpretty.activate
     def testIterateOverResults(self):
         '''Test the RequestSolrFetcher iteration over a mock set of data'''
@@ -210,26 +198,24 @@ class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
             'http://example.edu/solr/select',
             responses=[
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-0.json').read()),
+                    DIR_FIXTURES + '/ucb-cursor-results-0.json').read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-1.json').read()),
+                    DIR_FIXTURES + '/ucb-cursor-results-1.json').read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-2.json').read()),
+                    DIR_FIXTURES + '/ucb-cursor-results-2.json').read()),
                 httpretty.Response(body=open(
-                    DIR_FIXTURES +
-                    '/ucb-cursor-results-3.json').read()),
-            ]
-        )
-        h = fetcher.RequestsSolrFetcher('http://example.edu/solr',
-                'q=extra:data&auth=header:app-name:Value-with:in-it'
-                '&auth=header:app_key:111222333')
+                    DIR_FIXTURES + '/ucb-cursor-results-3.json').read()),
+            ])
+        h = fetcher.RequestsSolrFetcher(
+            'http://example.edu/solr',
+            'q=extra:data&auth=header:app-name:Value-with:in-it'
+            '&auth=header:app_key:111222333')
         h._page_size = 1
         self.assertEqual(h.q, 'extra:data')
-        self.assertEqual(h._headers, {'app-name': 'Value-with:in-it',
-                                      'app_key': '111222333'})
+        self.assertEqual(h._headers, {
+            'app-name': 'Value-with:in-it',
+            'app_key': '111222333'
+        })
         cursor = h._nextCursorMark
         docs = []
         docs.append(h.next())  # gets the one from init, no get_next_results
@@ -240,7 +226,7 @@ class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
         docs.append(h.next())  # get_next_results
         self.assertEqual(cursor, h._cursorMark)
         cursor = h._nextCursorMark
-        docs.append(h.next())   # get_next_results
+        docs.append(h.next())  # get_next_results
         self.assertEqual(cursor, h._cursorMark)
         self.assertEqual(len(docs), 4)
 
@@ -248,6 +234,7 @@ class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
 class HarvestSolr_ControllerTestCase(ConfigFileOverrideMixin, LogOverrideMixin,
                                      TestCase):
     '''Test the function of Solr harvest controller'''
+
     @httpretty.activate
     def setUp(self):
         super(HarvestSolr_ControllerTestCase, self).setUp()
@@ -255,20 +242,21 @@ class HarvestSolr_ControllerTestCase(ConfigFileOverrideMixin, LogOverrideMixin,
         httpretty.register_uri(
             httpretty.GET,
             "https://registry.cdlib.org/api/v1/collection/183/",
-            body=open(DIR_FIXTURES+'/collection_api_solr_harvest.json').read())
+            body=open(DIR_FIXTURES + '/collection_api_solr_harvest.json').read(
+            ))
         httpretty.register_uri(
             httpretty.POST,
             'http://example.edu/solr/blacklight/select',
-            body=open(
-                DIR_FIXTURES +
-                '/ucsd-new-feed-missions-bb3038949s-0.xml').read()
-                )
+            body=open(DIR_FIXTURES +
+                      '/ucsd-new-feed-missions-bb3038949s-0.xml').read())
         self.collection = Collection(
-                'https://registry.cdlib.org/api/v1/collection/183/')
+            'https://registry.cdlib.org/api/v1/collection/183/')
         self.setUp_config(self.collection)
         self.controller = fetcher.HarvestController(
-                'email@example.com', self.collection,
-                config_file=self.config_file, profile_path=self.profile_path)
+            'email@example.com',
+            self.collection,
+            config_file=self.config_file,
+            profile_path=self.profile_path)
         print "DIR SAVE::::: {}".format(self.controller.dir_save)
 
     def tearDown(self):
@@ -284,32 +272,31 @@ class HarvestSolr_ControllerTestCase(ConfigFileOverrideMixin, LogOverrideMixin,
             httpretty.POST,
             'http://example.edu/solr/blacklight/select',
             responses=[
-               httpretty.Response(body=open(
-                   DIR_FIXTURES +
-                   '/ucsd-new-feed-missions-bb3038949s-0.xml').read()),
-               httpretty.Response(body=open(
-                   DIR_FIXTURES +
-                   '/ucsd-new-feed-missions-bb3038949s-1.xml').read()),
-               httpretty.Response(body=open(
-                   DIR_FIXTURES +
-                   '/ucsd-new-feed-missions-bb3038949s-2.xml').read()),
-               httpretty.Response(body=open(
-                   DIR_FIXTURES +
-                   '/ucsd-new-feed-missions-bb3038949s-3.xml').read()),
-               httpretty.Response(body=open(
-                   DIR_FIXTURES +
-                   '/ucsd-new-feed-missions-bb3038949s-4.xml').read())
-            ]
-            )
+                httpretty.Response(body=open(
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-0.xml')
+                    .read()),
+                httpretty.Response(body=open(
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-1.xml')
+                    .read()),
+                httpretty.Response(body=open(
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-2.xml')
+                    .read()),
+                httpretty.Response(body=open(
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-3.xml')
+                    .read()),
+                httpretty.Response(body=open(
+                    DIR_FIXTURES + '/ucsd-new-feed-missions-bb3038949s-4.xml')
+                    .read())
+            ])
         self.assertTrue(hasattr(self.controller, 'harvest'))
         self.controller.harvest()
         print "LOGS:{}".format(self.test_log_handler.formatted_records)
         self.assertEqual(len(self.test_log_handler.records), 2)
         self.assertTrue(
-                'UC San Diego' in self.test_log_handler.formatted_records[0])
-        self.assertEqual(
-                self.test_log_handler.formatted_records[1],
-                '[INFO] HarvestController: 13 records harvested')
+            'UC San Diego' in self.test_log_handler.formatted_records[0])
+        self.assertEqual(self.test_log_handler.formatted_records[1],
+                         '[INFO] HarvestController: 13 records harvested')
+
 
 # Copyright © 2016, Regents of the University of California
 # All rights reserved.

--- a/test/test_solr_fetcher.py
+++ b/test/test_solr_fetcher.py
@@ -208,10 +208,10 @@ class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
             ])
         h = fetcher.RequestsSolrFetcher(
             'http://example.edu/solr',
-            'q=extra:data&auth=header:app-name:Value-with:in-it'
-            '&auth=header:app_key:111222333')
+            'q=extra:data&header=app-name:Value-with:in-it'
+            '&header=app_key:111222333')
         h._page_size = 1
-        self.assertEqual(h.q, 'extra:data')
+        self.assertEqual(h._query_params['q'], ['extra:data'])
         self.assertEqual(h._headers, {
             'app-name': 'Value-with:in-it',
             'app_key': '111222333'
@@ -229,6 +229,22 @@ class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
         docs.append(h.next())  # get_next_results
         self.assertEqual(cursor, h._cursorMark)
         self.assertEqual(len(docs), 4)
+
+    def test_url_request(self):
+        '''Test the url_request dynamic property of the fetcher'''
+        h = fetcher.RequestsSolrFetcher(
+            'http://example.edu/solr',
+            'q=extra:data&header=app-name:Value-with:in-it'
+            '&header=app_key:111222333')
+        self.assertEqual(
+            'http://example.edu/solr/select?rows=1000&cursorMark=None'
+            '&q=extra:data&wt=j&sort=i',
+            h.url_request)
+        h._cursorMark = 'XXXX'
+        self.assertEqual(
+            'http://example.edu/solr/select?rows=1000&cursorMark=XXXX'
+            '&q=extra:data&wt=j&sort=i',
+            h.url_request)
 
 
 class HarvestSolr_ControllerTestCase(ConfigFileOverrideMixin, LogOverrideMixin,

--- a/test/test_solr_fetcher.py
+++ b/test/test_solr_fetcher.py
@@ -238,12 +238,12 @@ class RequestsSolrFetcherTestCase(LogOverrideMixin, TestCase):
             '&header=app_key:111222333')
         self.assertEqual(
             'http://example.edu/solr/select?rows=1000&cursorMark=None'
-            '&q=extra:data&wt=j&sort=i',
+            '&q=extra:data&wt=json&sort=id asc',
             h.url_request)
         h._cursorMark = 'XXXX'
         self.assertEqual(
             'http://example.edu/solr/select?rows=1000&cursorMark=XXXX'
-            '&q=extra:data&wt=j&sort=i',
+            '&q=extra:data&wt=json&sort=id asc',
             h.url_request)
 
 


### PR DESCRIPTION
Can read a generic query string in extra data field.
url_harvest must point to full path of solr endpoint, no query string elements